### PR TITLE
Feature/27 Parallel Search

### DIFF
--- a/LyricsScraperNET.Client/Program.cs
+++ b/LyricsScraperNET.Client/Program.cs
@@ -23,7 +23,7 @@ class Program
         string artistToSearch = "Parkway Drive";
         string songToSearch = "Idols And Anchors";
 
-        //// The case when a song contains only an instrumental, without vocals.
+        //// Uncomment this block to test for instrumental songs (without vocals):
         //string artistToSearch = "Rush";
         //string songToSearch = "YYZ";
 
@@ -131,6 +131,9 @@ class Program
         //         .WithMusixmatch()
         //         .WithSongLyrics()
         //         .WithLyricFind();
+
+        //// To perform parallel searches across multiple external providers, enable the following option:
+        // lyricsScraperClient.UseParallelSearch = true;
 
         // To enable library logging, the LoggerFactory must be configured and passed to the client.
         var loggerFactory = LoggerFactory.Create(builder =>

--- a/LyricsScraperNET.Client/appsettings.json
+++ b/LyricsScraperNET.Client/appsettings.json
@@ -1,5 +1,6 @@
 {
   "LyricScraperClient": {
+    "UseParallelSearch":  false,
     "GeniusOptions": {
       "SearchPriority": 3,
       "Enabled": true,

--- a/LyricsScraperNET/Configuration/ILyricScraperClientConfig.cs
+++ b/LyricsScraperNET/Configuration/ILyricScraperClientConfig.cs
@@ -9,6 +9,12 @@ namespace LyricsScraperNET.Configuration
         /// </summary>
         bool IsEnabled { get; }
 
+        /// <summary>
+        /// Enable parallel search instead of sequential, 
+        /// searching across all available external providers.
+        /// </summary>
+        bool UseParallelSearch { get; }
+
         IExternalProviderOptions AZLyricsOptions { get; }
 
         IExternalProviderOptions GeniusOptions { get; }

--- a/LyricsScraperNET/Configuration/LyricScraperClientConfig.cs
+++ b/LyricsScraperNET/Configuration/LyricScraperClientConfig.cs
@@ -23,6 +23,10 @@ namespace LyricsScraperNET.Configuration
 
         public IExternalProviderOptions LyricFindOptions { get; set; } = new LyricFindOptions();
 
+        /// <inheritdoc />
+        public bool UseParallelSearch { get; } = false;
+
+        /// <inheritdoc />
         public bool IsEnabled => AZLyricsOptions.Enabled
             || GeniusOptions.Enabled
             || MusixmatchOptions.Enabled

--- a/LyricsScraperNET/Configuration/LyricScraperClientConfig.cs
+++ b/LyricsScraperNET/Configuration/LyricScraperClientConfig.cs
@@ -24,7 +24,7 @@ namespace LyricsScraperNET.Configuration
         public IExternalProviderOptions LyricFindOptions { get; set; } = new LyricFindOptions();
 
         /// <inheritdoc />
-        public bool UseParallelSearch { get; } = false;
+        public bool UseParallelSearch { get; set; } = false;
 
         /// <inheritdoc />
         public bool IsEnabled => AZLyricsOptions.Enabled

--- a/LyricsScraperNET/ILyricsScraperClient.cs
+++ b/LyricsScraperNET/ILyricsScraperClient.cs
@@ -16,6 +16,14 @@ namespace LyricsScraperNET
         /// </summary>
         bool IsEnabled { get; }
 
+        /// <summary>
+        /// Determines whether to use parallel search instead of sequential search. 
+        /// If explicitly set, the value from the local variable is used. 
+        /// Otherwise, it falls back to the configuration setting. 
+        /// By default, sequential search is used if not specified.
+        /// </summary>
+        bool UseParallelSearch { get; set; }
+
         IExternalProvider this[ExternalProviderType providerType] { get; }
 
         /// <summary>

--- a/LyricsScraperNET/Models/Responses/SearchResult.cs
+++ b/LyricsScraperNET/Models/Responses/SearchResult.cs
@@ -62,5 +62,14 @@ namespace LyricsScraperNET.Models.Responses
         /// Returns true if the field <seealso cref="LyricText"/> is empty.
         /// </summary>
         public bool IsEmpty() => string.IsNullOrWhiteSpace(LyricText);
+
+        /// <summary>
+        /// Represents an empty search result.
+        /// </summary>
+        public static SearchResult Empty { get; } = new SearchResult
+        {
+            ResponseStatusCode = ResponseStatusCode.NoDataFound,
+            Instrumental = false
+        };
     }
 }

--- a/Tests/LyricsScraperNET.UnitTest/Configuration/LyricScraperClientConfigTest.cs
+++ b/Tests/LyricsScraperNET.UnitTest/Configuration/LyricScraperClientConfigTest.cs
@@ -14,5 +14,15 @@ namespace LyricsScraperNET.UnitTest.Configuration
             // Assert
             Assert.False(lyricScraperClientConfig.IsEnabled);
         }
+
+        [Fact]
+        public void LyricScraperClientConfig_UseParallelSearch_ReturnsFalseByDefault()
+        {
+            // Act
+            var lyricScraperClientConfig = new LyricScraperClientConfig();
+
+            // Assert
+            Assert.False(lyricScraperClientConfig.UseParallelSearch);
+        }
     }
 }

--- a/Tests/LyricsScraperNET.UnitTest/Configuration/ServiceCollectionExtensionsTest.cs
+++ b/Tests/LyricsScraperNET.UnitTest/Configuration/ServiceCollectionExtensionsTest.cs
@@ -89,6 +89,7 @@ namespace LyricsScraperNET.UnitTest.Configuration
             // Assert
             Assert.NotNull(service);
             Assert.True(service.IsEnabled);
+            Assert.True(service.UseParallelSearch);
 
             foreach (var providerType in externalProviderTypes)
             {

--- a/Tests/LyricsScraperNET.UnitTest/Resources/full_test_settings.json
+++ b/Tests/LyricsScraperNET.UnitTest/Resources/full_test_settings.json
@@ -1,5 +1,6 @@
 {
   "LyricScraperClient": {
+    "UseParallelSearch": true,
     "GeniusOptions": {
       "SearchPriority": 11,
       "Enabled": true,


### PR DESCRIPTION
Feature #27:

- Added a `UseParallelSearch` configuration option to enable parallel searches across multiple providers.
- Implemented logic to return the first successful result and cancel remaining searches using a `CancellationToken`.
- Included unit tests to validate the functionality of parallel search and configuration behavior.